### PR TITLE
Whitelist distribution files when publishing NPM module

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,13 @@
 	"description": "An ESnext spec-compliant `Array.prototype.flatMap` shim/polyfill/replacement that works as far down as ES3.",
 	"license": "MIT",
 	"main": "index",
+	"files": [
+		"index.js",
+		"auto.js",
+		"implementation.js",
+		"polyfill.js",
+		"shim.js"
+	],
 	"scripts": {
 		"prepublish": "safe-publish-latest",
 		"pretest": "npm run --silent lint && evalmd README.md",


### PR DESCRIPTION
Thanks for your work with this module 🙏 

The published NPM module contains the following files and folders:
![image](https://user-images.githubusercontent.com/13087421/58372168-5c0b5780-7f4c-11e9-93bd-63008f646bc7.png)

In the spirit of keeping module sizes small, this PR whitelists only the necessary distribution files :)

